### PR TITLE
Add order form

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { BrowserRouter, Route } from 'react-router-dom';
 import CartPage from 'features/CartPage';
+import OrderForm from 'features/OrderForm';
 
 function App(props) {
   const { store } = props;
@@ -11,6 +12,7 @@ function App(props) {
     <Provider store={store}>
       <BrowserRouter>
         <Route exact path="/cart" component={CartPage} />
+        <Route exact path="/order" component={OrderForm} />
       </BrowserRouter>
     </Provider>
   );

--- a/app/src/components/StoreItem/index.js
+++ b/app/src/components/StoreItem/index.js
@@ -31,7 +31,7 @@ StoreItem.propTypes = {
   name: PropTypes.string.isRequired,
   description: PropTypes.string,
   price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  amount: PropTypes.number.isRequired,
+  amount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 };
 
 StoreItem.defaultProps = {

--- a/app/src/ducks/cart.js
+++ b/app/src/ducks/cart.js
@@ -1,14 +1,24 @@
-import { get } from 'axios';
+import { get, post } from 'axios';
+import { setSuccess } from 'ducks/ui/success';
+import { setError } from 'ducks/ui/error';
 import { fromJS } from 'immutable';
 import { all, put, takeEvery } from 'redux-saga/effects';
 
 const CART_API = 'http://localhost:5555';
 
 // Actions
+const ADD = 'app/entities/cart/ADD';
 const REQUEST = 'app/entities/cart/REQUEST';
 const RECEIVE = 'app/entities/cart/RECEIVE';
 
 // Action Creators
+export function addItem(item) {
+  return {
+    type: ADD,
+    payload: item,
+  };
+}
+
 export function fetchCart() {
   return {
     type: REQUEST,
@@ -43,14 +53,28 @@ function* requestCart() {
   yield put(receiveCart({ items }));
 }
 
+function* requestAddItem({ payload }) {
+  const url = `${CART_API}/item/add`;
+  try {
+    yield post(url, payload);
+    yield put(setSuccess('orderForm'));
+  } catch (err) {
+    yield put(setError('orderForm'));
+  }
+}
 
 // Sagas
+function* watchAddItem() {
+  yield takeEvery(ADD, requestAddItem);
+}
+
 function* watchRequestCart() {
   yield takeEvery(REQUEST, requestCart);
 }
 
 function* sagas() {
   yield all([
+    watchAddItem(),
     watchRequestCart(),
   ]);
 }

--- a/app/src/ducks/cart.js
+++ b/app/src/ducks/cart.js
@@ -58,8 +58,8 @@ function* requestAddItem({ payload }) {
   try {
     yield post(url, payload);
     yield put(setSuccess('orderForm'));
-  } catch (err) {
-    yield put(setError('orderForm'));
+  } catch ({ response: { data } = {} }) {
+    yield put(setError('orderForm', data));
   }
 }
 

--- a/app/src/ducks/ui/error.js
+++ b/app/src/ducks/ui/error.js
@@ -1,0 +1,42 @@
+// Actions
+import { fromJS, isImmutable } from 'immutable';
+
+const REMOVE = 'app/ui/error/REMOVE';
+const SET = 'app/ui/error/SET';
+
+// Action Creators
+export function removeError(tag) {
+  return {
+    type: REMOVE,
+    tag,
+  };
+}
+
+export function setError(tag, metadata) {
+  return {
+    type: SET,
+    tag,
+    metadata,
+  };
+}
+
+
+// Reducer
+export default function reducer(state = fromJS({}), action = {}) {
+  const { metadata, tag, type } = action;
+  switch (type) {
+    case REMOVE: {
+      return state.deleteIn([tag]);
+    }
+    case SET: {
+      return state.merge(fromJS({ [tag]: metadata || true }));
+    }
+    default: return state;
+  }
+}
+
+// Selectors
+export function selectError(state, tag) {
+  const error = state.ui.error.get(tag);
+  return isImmutable(error) ? error.toJS() : error;
+}

--- a/app/src/ducks/ui/index.js
+++ b/app/src/ducks/ui/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import error from 'ducks/ui/error';
+import success from 'ducks/ui/success';
+
+export default combineReducers({
+  error,
+  success,
+});

--- a/app/src/ducks/ui/success.js
+++ b/app/src/ducks/ui/success.js
@@ -1,0 +1,41 @@
+// Actions
+import { fromJS, isImmutable } from 'immutable';
+
+const SET = 'app/ui/success/SET';
+const REMOVE = 'app/ui/success/REMOVE';
+
+// Action Creators
+export function removeSuccess(tag) {
+  return {
+    type: REMOVE,
+    tag,
+  };
+}
+
+export function setSuccess(tag, metadata) {
+  return {
+    type: SET,
+    tag,
+    metadata,
+  };
+}
+
+// Reducer
+export default function reducer(state = fromJS({}), action = {}) {
+  const { metadata, tag, type } = action;
+  switch (type) {
+    case REMOVE: {
+      return state.deleteIn([tag]);
+    }
+    case SET: {
+      return state.merge(fromJS({ [tag]: metadata || true }));
+    }
+    default: return state;
+  }
+}
+
+// Selectors
+export function selectSuccess(state, tag) {
+  const success = state.ui.success.get(tag);
+  return isImmutable(success) ? success.toJS() : success;
+}

--- a/app/src/features/CartPage/CartPage.js
+++ b/app/src/features/CartPage/CartPage.js
@@ -27,7 +27,7 @@ CartPage.propTypes = {
     name: PropTypes.string.isRequired,
     description: PropTypes.string,
     price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-    amount: PropTypes.number.isRequired,
+    amount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   })).isRequired,
 };
 

--- a/app/src/features/CartPage/index.js
+++ b/app/src/features/CartPage/index.js
@@ -34,7 +34,7 @@ CartPageContainer.propTypes = {
     name: PropTypes.string.isRequired,
     description: PropTypes.string,
     price: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-    amount: PropTypes.number.isRequired,
+    amount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   })).isRequired,
 };
 

--- a/app/src/features/OrderForm/OrderForm.js
+++ b/app/src/features/OrderForm/OrderForm.js
@@ -18,7 +18,11 @@ class OrderForm extends React.PureComponent {
   }
 
   submitOrder(event) {
+    const { addItem, clearError, clearSuccess } = this.props;
     event.preventDefault();
+    clearError();
+    clearSuccess();
+    addItem(this.state);
   }
 
   render() {
@@ -58,11 +62,8 @@ class OrderForm extends React.PureComponent {
 
 OrderForm.propTypes = {
   addItem: PropTypes.func.isRequired,
-  addSuccess: PropTypes.bool,
-};
-
-OrderForm.defaultProps = {
-  addSuccess: null,
+  clearError: PropTypes.func.isRequired,
+  clearSuccess: PropTypes.func.isRequired,
 };
 
 export default OrderForm;

--- a/app/src/features/OrderForm/OrderForm.js
+++ b/app/src/features/OrderForm/OrderForm.js
@@ -26,9 +26,13 @@ class OrderForm extends React.PureComponent {
   }
 
   render() {
+    const { addError } = this.props;
     return (
       <div className="orderForm">
-        <form onSubmit={this.submitOrder}>
+        { addError && (
+          <p className="error">{addError}</p>
+        )}
+        <form noValidate onSubmit={this.submitOrder}>
           <input
             onChange={this.onChange}
             name="name"
@@ -62,8 +66,13 @@ class OrderForm extends React.PureComponent {
 
 OrderForm.propTypes = {
   addItem: PropTypes.func.isRequired,
+  addError: PropTypes.string,
   clearError: PropTypes.func.isRequired,
   clearSuccess: PropTypes.func.isRequired,
+};
+
+OrderForm.defaultProps = {
+  addError: null,
 };
 
 export default OrderForm;

--- a/app/src/features/OrderForm/OrderForm.js
+++ b/app/src/features/OrderForm/OrderForm.js
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import './OrderForm.scss';
+
+class OrderForm extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.onChange = this.onChange.bind(this);
+    this.submitOrder = this.submitOrder.bind(this);
+  }
+
+  onChange({ target: { name, value } }) {
+    this.setState((prevState) => ({
+      ...prevState,
+      [name]: value,
+    }));
+  }
+
+  submitOrder(event) {
+    event.preventDefault();
+  }
+
+  render() {
+    return (
+      <div className="orderForm">
+        <form onSubmit={this.submitOrder}>
+          <input
+            onChange={this.onChange}
+            name="name"
+            placeholder="Product Name"
+            type="text"
+          />
+          <input
+            onChange={this.onChange}
+            name="amount"
+            placeholder="Amount"
+            type="number"
+          />
+          <input
+            onChange={this.onChange}
+            name="price"
+            placeholder="Price"
+            type="number"
+          />
+          <textarea
+            onChange={this.onChange}
+            name="description"
+            placeholder="Description"
+            type="text"
+          />
+          <button type="submit">Submit</button>
+        </form>
+      </div>
+    );
+  }
+}
+
+OrderForm.propTypes = {
+  addItem: PropTypes.func.isRequired,
+  addSuccess: PropTypes.bool,
+};
+
+OrderForm.defaultProps = {
+  addSuccess: null,
+};
+
+export default OrderForm;

--- a/app/src/features/OrderForm/OrderForm.scss
+++ b/app/src/features/OrderForm/OrderForm.scss
@@ -23,4 +23,11 @@
   button {
     border-bottom: 0;
   }
+
+  .error {
+    background-color: lightcoral;
+    color: darkred;
+    outline: 1px solid red;
+    padding: 15px;
+  }
 }

--- a/app/src/features/OrderForm/OrderForm.scss
+++ b/app/src/features/OrderForm/OrderForm.scss
@@ -1,0 +1,26 @@
+.orderForm {
+  background-color: darkgrey;
+  min-width: 320px;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 15px;
+  position: relative;
+
+
+  input, textarea, button {
+    border: solid 1px #e0dddb;
+    border-bottom: 0;
+    box-sizing: border-box;         /* Opera/IE 8+ */
+    -moz-box-sizing: border-box;    /* Firefox, other Gecko */
+    -webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
+    display: block;
+    height: 50px;
+    padding: 15px;
+    position: relative;
+    width: 100%;
+  }
+
+  button {
+    border-bottom: 0;
+  }
+}

--- a/app/src/features/OrderForm/index.js
+++ b/app/src/features/OrderForm/index.js
@@ -1,38 +1,47 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import { Redirect } from 'react-router';
+import { addItem } from 'ducks/cart';
+import { removeSuccess, selectSuccess } from 'ducks/ui/success';
+import { removeError, selectError } from 'ducks/ui/error';
 import OrderForm from './OrderForm';
 
 class OrderFormContainer extends React.PureComponent {
   render() {
+    if (this.props.addSuccess) {
+      return <Redirect to="/cart" />;
+    }
     return (
       <OrderForm
         addItem={this.props.addItem}
-        addSuccess={this.props.addSuccess}
+        clearError={this.props.clearError}
+        clearSuccess={this.props.clearSuccess}
       />
     );
   }
 }
 
-OrderFormContainer.propTypes = {
-
-};
-
 function mapDispatchToProps(dispatch) {
   return {
-    addItem: () => dispatch(() => {}),
+    addItem: (item) => dispatch(addItem(item)),
+    clearError: () => dispatch(removeError('orderForm')),
+    clearSuccess: () => dispatch(removeSuccess('orderForm')),
   };
 }
 
 function mapStateToProps(state) {
   return {
-    addSuccess: true,
+    addSuccess: selectSuccess(state, 'orderForm'),
+    addFailure: selectError(state, 'orderForm'),
   };
 }
 
 OrderFormContainer.propTypes = {
   addItem: PropTypes.func.isRequired,
   addSuccess: PropTypes.bool,
+  clearError: PropTypes.func.isRequired,
+  clearSuccess: PropTypes.func.isRequired,
 };
 
 OrderFormContainer.defaultProps = {

--- a/app/src/features/OrderForm/index.js
+++ b/app/src/features/OrderForm/index.js
@@ -14,6 +14,7 @@ class OrderFormContainer extends React.PureComponent {
     }
     return (
       <OrderForm
+        addError={this.props.addError}
         addItem={this.props.addItem}
         clearError={this.props.clearError}
         clearSuccess={this.props.clearSuccess}
@@ -32,6 +33,7 @@ function mapDispatchToProps(dispatch) {
 
 function mapStateToProps(state) {
   return {
+    addError: selectError(state, 'orderForm'),
     addSuccess: selectSuccess(state, 'orderForm'),
     addFailure: selectError(state, 'orderForm'),
   };
@@ -39,12 +41,14 @@ function mapStateToProps(state) {
 
 OrderFormContainer.propTypes = {
   addItem: PropTypes.func.isRequired,
+  addError: PropTypes.string,
   addSuccess: PropTypes.bool,
   clearError: PropTypes.func.isRequired,
   clearSuccess: PropTypes.func.isRequired,
 };
 
 OrderFormContainer.defaultProps = {
+  addError: null,
   addSuccess: null,
 };
 

--- a/app/src/features/OrderForm/index.js
+++ b/app/src/features/OrderForm/index.js
@@ -1,0 +1,42 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import OrderForm from './OrderForm';
+
+class OrderFormContainer extends React.PureComponent {
+  render() {
+    return (
+      <OrderForm
+        addItem={this.props.addItem}
+        addSuccess={this.props.addSuccess}
+      />
+    );
+  }
+}
+
+OrderFormContainer.propTypes = {
+
+};
+
+function mapDispatchToProps(dispatch) {
+  return {
+    addItem: () => dispatch(() => {}),
+  };
+}
+
+function mapStateToProps(state) {
+  return {
+    addSuccess: true,
+  };
+}
+
+OrderFormContainer.propTypes = {
+  addItem: PropTypes.func.isRequired,
+  addSuccess: PropTypes.bool,
+};
+
+OrderFormContainer.defaultProps = {
+  addSuccess: null,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(OrderFormContainer);

--- a/app/src/rootReducer.js
+++ b/app/src/rootReducer.js
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux';
 import cart from 'ducks/cart';
+import ui from 'ducks/ui';
 
 export default combineReducers({
   cart: cart.reducer,
+  ui,
 });

--- a/cart-backend/index.js
+++ b/cart-backend/index.js
@@ -1,13 +1,15 @@
 /**
  * Backend application listening on port 5555 that accepts Restful APIs.
- * 
+ *
  * 1- GET /list : API returns the whole cart list in json format
  * 2- POST /item/add : API that receives a new cart item as a json request and adds it to the current cart list
  */
 
 const express = require('express');
+const cors = require('cors');
 const app = express(); // creates an express application
 app.use(express.json()); // this will make the app parse json body sent in the POST request
+app.use(cors());
 
 const cartList = [
     { id: 1, name: "Laptop", description: "512 MB ram, webcam, microphone, keyboard", price: 20, amount: 2 },

--- a/cart-backend/package-lock.json
+++ b/cart-backend/package-lock.json
@@ -60,6 +60,15 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -230,6 +239,11 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "on-finished": {
       "version": "2.3.0",

--- a/cart-backend/package.json
+++ b/cart-backend/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.16.4"
   }
 }


### PR DESCRIPTION
### Why
The project specifies that there needs to be an order form.  The form should allow the user to specify the `name, `amount`, `price`, and `description` of the product they want to order.

### How
Create a basic `OrderForm` feature that collects information and dispatches it to the backend api, on success it redirects to the cart.  On failure, it will display the error from the API.